### PR TITLE
Alterations Needed for New Controller Plugin for Emoncms

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -161,7 +161,7 @@ struct SecurityStruct
   char          WifiKey[64];
   char          WifiAPKey[64];
   char          ControllerUser[26];
-  char          ControllerPassword[26];
+  char          ControllerPassword[35];
   char          Password[26];
 } SecuritySettings;
 

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -290,7 +290,7 @@ void handle_config() {
     controlleruser.toCharArray(tmpString, 26);
     urlDecode(tmpString);
     strcpy(SecuritySettings.ControllerUser, tmpString);
-    controllerpassword.toCharArray(tmpString, 26);
+    controllerpassword.toCharArray(tmpString, 35);
     urlDecode(tmpString);
     strcpy(SecuritySettings.ControllerPassword, tmpString);
     if (Settings.Protocol != protocol.toInt())


### PR DESCRIPTION
First of the alterations to allow a new controller plugin for emoncms.org.
Password or apikey can be 32-34 characters long