### PR TITLE
Update To enable unit numbers to pass to emoncms as node numbers

### DIFF
--- a/_C007.ino
+++ b/_C007.ino
@@ -50,7 +50,9 @@ boolean CPlugin_007(byte function, struct EventStruct *event)
         if (connectionFailures)
           connectionFailures--;
 
-        String postDataStr = F("GET /emoncms/input/post.json?json=");
+        String postDataStr = F("GET /emoncms/input/post.json?node=");
+        postDataStr += Settings.Unit;
+        postDataStr += F("&json=");
         
         switch (event->sensorType)
         {


### PR DESCRIPTION
Sorry about this Afterthought.
This enables the ESPEasy unit number to be passed to emoncms as a node number.
This means in Emoncms that every Unit will be on a seperate Node.