### PR TITLE
Some more space for storing UICODE Chars so you can use realy 64 Byte…

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -181,7 +181,7 @@ WiFiUDP portTX;
 struct SecurityStruct
 {
   char          WifiSSID[32];
-  char          WifiKey[64];
+  char          WifiKey[76];
   char          WifiAPKey[64];
   char          ControllerUser[26];
   char          ControllerPassword[64];

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -261,7 +261,7 @@ void handle_config() {
     ssid.toCharArray(tmpString, 26);
     urlDecode(tmpString);
     strcpy(SecuritySettings.WifiSSID, tmpString);
-    key.toCharArray(tmpString, 64);
+    key.toCharArray(tmpString, sizeof(SecuritySettings.WifiKey));
     urlDecode(tmpString);
     strcpy(SecuritySettings.WifiKey, tmpString);
     apkey.toCharArray(tmpString, 64);


### PR DESCRIPTION
… Passwords.

The actual implementation cannot deal with 64 Character Passwords  containig Unicodes Chars using mor than one byte. The Reason is because they are converted from String to Char using the toCharArray Method. This method converts to UNICODE. So if the password ihas 64 symbols and some symbols cannnot be stored in a single char of the 
char  WifiKey[64];
array the password is truncated. Thus the array has to be enlarged. How large it hast to be depends on the used Passwords. For my Usecase the additonal 12 bytes are sufficient. 