### PR TITLE
WIFIKey containing 64 Symbols including ! is no longer truncated

### DIFF
--- a/Controller.ino
+++ b/Controller.ino
@@ -34,7 +34,7 @@ void callback(const MQTT::Publish& pub) {
   topic.toCharArray(c_topic, 80);
   sprintf_P(log, PSTR("%s%s"), "MQTT : Topic ", c_topic);
   addLog(LOG_LEVEL_DEBUG, log);
-
+  
   struct EventStruct TempEvent;
   TempEvent.String1 = topic;
   TempEvent.String2 = message;
@@ -197,7 +197,7 @@ boolean nodeVariableCopy(byte var, byte unit)
 /*********************************************************************************************\
  * Syslog client
 \*********************************************************************************************/
-void syslog(char *message)
+void syslog(const char *message)
 {
   if (Settings.Syslog_IP[0] != 0)
   {

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -166,7 +166,7 @@ Servo myservo1;
 Servo myservo2;
 
 // MQTT client
-PubSubClient MQTTclient("", 1886);
+PubSubClient MQTTclient("");
 
 // LCD
 LiquidCrystal_I2C lcd(0x27, 20, 4); // set the LCD address to 0x27 for a 16 chars and 2 line display

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -166,7 +166,7 @@ Servo myservo1;
 Servo myservo2;
 
 // MQTT client
-PubSubClient MQTTclient("");
+PubSubClient MQTTclient("", 1886);
 
 // LCD
 LiquidCrystal_I2C lcd(0x27, 20, 4); // set the LCD address to 0x27 for a 16 chars and 2 line display
@@ -181,7 +181,7 @@ WiFiUDP portTX;
 struct SecurityStruct
 {
   char          WifiSSID[32];
-  char          WifiKey[76];
+  char          WifiKey[64];
   char          WifiAPKey[64];
   char          ControllerUser[26];
   char          ControllerPassword[64];
@@ -571,9 +571,7 @@ void SensorSend()
             String svalue = String(value);
             formula.replace("%pvalue%", spreValue);
             formula.replace("%value%", svalue);
-            char TmpStr[26];
-            formula.toCharArray(TmpStr, 25);
-            byte error = Calculate(TmpStr, &result);
+            byte error = Calculate(formula.c_str(), &result);
             if (error == 0)
               UserVar[varIndex + varNr] = result;
           }

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -181,7 +181,7 @@ WiFiUDP portTX;
 struct SecurityStruct
 {
   char          WifiSSID[32];
-  char          WifiKey[64];
+  char          WifiKey[76];
   char          WifiAPKey[64];
   char          ControllerUser[26];
   char          ControllerPassword[64];

--- a/Misc.ino
+++ b/Misc.ino
@@ -67,7 +67,7 @@ byte getProtocolIndex(byte Number)
 /********************************************************************************************\
 * Find positional parameter in a char string
 \*********************************************************************************************/
-boolean GetArgv(char *string, char *argv, int argc)
+boolean GetArgv(const char *string, char *argv, int argc)
 {
   int string_pos = 0, argv_pos = 0, argc_pos = 0;
   char c, d;
@@ -532,13 +532,10 @@ float ul2float(unsigned long ul)
 \*********************************************************************************************/
 void addLog(byte loglevel, String& string)
 {
-  char log[80];
-  string.toCharArray(log,80);
-  addLog(loglevel, log);
+  addLog(loglevel, string.c_str());
 }
 
-
-void addLog(byte loglevel, char *line)
+void addLog(byte loglevel, const char *line)
 {
   if (loglevel <= Settings.SerialLogLevel)
     Serial.println(line);
@@ -554,6 +551,7 @@ void addLog(byte loglevel, char *line)
     Logging[logcount].timeStamp = millis();
     Logging[logcount].Message = line;
   }
+  Serial.println(line);  
 }
 
 

--- a/Misc.ino
+++ b/Misc.ino
@@ -551,7 +551,6 @@ void addLog(byte loglevel, const char *line)
     Logging[logcount].timeStamp = millis();
     Logging[logcount].Message = line;
   }
-  Serial.println(line);  
 }
 
 

--- a/Serial.ino
+++ b/Serial.ino
@@ -2,7 +2,7 @@
 * Process data from Serial Interface
 \*********************************************************************************************/
 #define INPUT_COMMAND_SIZE          80
-void ExecuteCommand(char *Line)
+void ExecuteCommand(const char *Line)
 {
   char TmpStr1[80];
   TmpStr1[0] = 0;

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -261,7 +261,7 @@ void handle_config() {
     ssid.toCharArray(tmpString, 26);
     urlDecode(tmpString);
     strcpy(SecuritySettings.WifiSSID, tmpString);
-    key.toCharArray(tmpString, 64);
+    key.toCharArray(tmpString, sizeof(SecuritySettings.WifiKey));
     urlDecode(tmpString);
     strcpy(SecuritySettings.WifiKey, tmpString);
     apkey.toCharArray(tmpString, 64);

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -113,20 +113,16 @@ void handle_root() {
   if (!isLoggedIn()) return;
 
   int freeMem = ESP.getFreeHeap();
-  String webrequest = WebServer.arg("cmd");
-  char command[80];
-  command[0] = 0;
-  webrequest.toCharArray(command, 80);
-  urlDecode(command);
+  String sCommand = urlDecode(WebServer.arg("cmd").c_str());
 
-  if ((strcasecmp_P(command, PSTR("wifidisconnect")) != 0) && (strcasecmp_P(command, PSTR("reboot")) != 0))
+  if ((strcasecmp_P(sCommand.c_str(), PSTR("wifidisconnect")) != 0) && (strcasecmp_P(sCommand.c_str(), PSTR("reboot")) != 0))
   {
     String reply = "";
     addMenu(reply);
 
     printToWeb = true;
     printWebString = "";
-    ExecuteCommand(command);
+    ExecuteCommand(sCommand.c_str());
 
     reply += printWebString;
     reply += F("<form>");
@@ -206,14 +202,14 @@ void handle_root() {
     // have to disconnect or reboot from within the main loop
     // because the webconnection is still active at this point
     // disconnect here could result into a crash/reboot...
-    if (strcasecmp_P(command, PSTR("wifidisconnect")) == 0)
+    if (strcasecmp_P(sCommand.c_str(), PSTR("wifidisconnect")) == 0)
     {
       String log = F("WIFI : Disconnecting...");
       addLog(LOG_LEVEL_INFO, log);
       cmd_within_mainloop = CMD_WIFI_DISCONNECT;
     }
 
-    if (strcasecmp_P(command, PSTR("reboot")) == 0)
+    if (strcasecmp_P(sCommand.c_str(), PSTR("reboot")) == 0)
     {
       String log = F("     : Rebooting...");
       addLog(LOG_LEVEL_INFO, log);
@@ -233,49 +229,39 @@ void handle_config() {
 
   char tmpString[64];
 
-  String name = WebServer.arg("name");
-  String password = WebServer.arg("password");
-  String ssid = WebServer.arg("ssid");
-  String key = WebServer.arg("key");
-  String controllerip = WebServer.arg("controllerip");
-  String controllerport = WebServer.arg("controllerport");
-  String protocol = WebServer.arg("protocol");
-  String controlleruser = WebServer.arg("controlleruser");
-  String controllerpassword = WebServer.arg("controllerpassword");
-  String sensordelay = WebServer.arg("delay");
-  String deepsleep = WebServer.arg("deepsleep");
-  String espip = WebServer.arg("espip");
-  String espgateway = WebServer.arg("espgateway");
-  String espsubnet = WebServer.arg("espsubnet");
-  String unit = WebServer.arg("unit");
-  String apkey = WebServer.arg("apkey");
+  
+
+  String name = urlDecode(WebServer.arg("name").c_str());
+  String password = urlDecode(WebServer.arg("password").c_str());
+  String ssid = urlDecode(WebServer.arg("ssid").c_str());
+  String key = urlDecode(WebServer.arg("key").c_str());
+  String controllerip = urlDecode(WebServer.arg("controllerip").c_str());
+  String controllerport = urlDecode(WebServer.arg("controllerport").c_str());
+  String protocol = urlDecode(WebServer.arg("protocol").c_str());
+  String controlleruser = urlDecode(WebServer.arg("controlleruser").c_str());
+  String controllerpassword = urlDecode(WebServer.arg("controllerpassword").c_str());
+  String sensordelay = urlDecode(WebServer.arg("delay").c_str());
+  String deepsleep = urlDecode(WebServer.arg("deepsleep").c_str());
+  String espip = urlDecode(WebServer.arg("espip").c_str());
+  String espgateway = urlDecode(WebServer.arg("espgateway").c_str());
+  String espsubnet = urlDecode(WebServer.arg("espsubnet").c_str());
+  String unit = urlDecode(WebServer.arg("unit").c_str());
+  String apkey = urlDecode(WebServer.arg("apkey").c_str());
 
   if (ssid[0] != 0)
   {
-    name.toCharArray(tmpString, 26);
-    urlDecode(tmpString);
-    strcpy(Settings.Name, tmpString);
-    password.toCharArray(tmpString, 26);
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.Password, tmpString);
-    ssid.toCharArray(tmpString, 26);
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.WifiSSID, tmpString);
-    key.toCharArray(tmpString, sizeof(SecuritySettings.WifiKey));
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.WifiKey, tmpString);
-    apkey.toCharArray(tmpString, 64);
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.WifiAPKey, tmpString);
+    strncpy(Settings.Name, name.c_str(), sizeof(Settings.Name));
+    strncpy(SecuritySettings.Password, password.c_str(), sizeof(SecuritySettings.Password));
+    strncpy(SecuritySettings.WifiSSID, ssid.c_str(), sizeof(SecuritySettings.WifiSSID));
+    strncpy(SecuritySettings.WifiKey, key.c_str(), sizeof(SecuritySettings.WifiKey));
+    strncpy(SecuritySettings.WifiAPKey, apkey.c_str(), sizeof(SecuritySettings.WifiAPKey));
+
     controllerip.toCharArray(tmpString, 26);
     str2ip(tmpString, Settings.Controller_IP);
     Settings.ControllerPort = controllerport.toInt();
-    controlleruser.toCharArray(tmpString, 26);
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.ControllerUser, tmpString);
-    controllerpassword.toCharArray(tmpString, 64);
-    urlDecode(tmpString);
-    strcpy(SecuritySettings.ControllerPassword, tmpString);
+    
+    strncpy(SecuritySettings.ControllerUser, controlleruser.c_str(), sizeof(SecuritySettings.ControllerUser));
+    strncpy(SecuritySettings.ControllerPassword, controllerpassword.c_str(), sizeof(SecuritySettings.ControllerPassword));
     if (Settings.Protocol != protocol.toInt())
     {
       Settings.Protocol = protocol.toInt();
@@ -1402,38 +1388,45 @@ boolean isLoggedIn()
 //********************************************************************************
 // Decode special characters in URL of get/post data
 //********************************************************************************
-void urlDecode(char *src)
+String urlDecode(const char *src)
 {
-  char* dst = src;
+  String rString;
+  const char* dst = src;
   char a, b;
+
   while (*src) {
 
     if (*src == '+')
-      *src = ' ';
-
-    if ((*src == '%') &&
-        ((a = src[1]) && (b = src[2])) &&
-        (isxdigit(a) && isxdigit(b))) {
-      if (a >= 'a')
-        a -= 'a' - 'A';
-      if (a >= 'A')
-        a -= ('A' - 10);
-      else
-        a -= '0';
-      if (b >= 'a')
-        b -= 'a' - 'A';
-      if (b >= 'A')
-        b -= ('A' - 10);
-      else
-        b -= '0';
-      *dst++ = 16 * a + b;
-      src += 3;
+    {
+      rString += ' ';
+      src++;
     }
-    else {
-      *dst++ = *src++;
+    else
+    {
+      if ((*src == '%') &&
+          ((a = src[1]) && (b = src[2])) &&
+          (isxdigit(a) && isxdigit(b))) {
+        if (a >= 'a')
+          a -= 'a' - 'A';
+        if (a >= 'A')
+          a -= ('A' - 10);
+        else
+          a -= '0';
+        if (b >= 'a')
+          b -= 'a' - 'A';
+        if (b >= 'A')
+          b -= ('A' - 10);
+        else
+          b -= '0';
+        rString += (char)(16 * a + b);
+        src += 3;
+      }
+      else {
+        rString += *src++;
+      }
     }
   }
-  *dst++ = '\0';
+  return rString;
 }
 
 #if FEATURE_SPIFFS

--- a/_P012_LCD.ino
+++ b/_P012_LCD.ino
@@ -73,11 +73,8 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
           String arg = "Plugin_012_template";
           arg += varNr + 1;
           arg.toCharArray(argc, 25);
-          String tmpString = WebServer.arg(argc);
-          char tmp[81];
-          tmpString.toCharArray(tmp, 81);
-          urlDecode(tmp);
-          strcpy(deviceTemplate[varNr], tmp);
+          String tmpString = urlDecode(WebServer.arg(argc).c_str());
+          strncpy(deviceTemplate[varNr], tmpString.c_str(), sizeof(deviceTemplate[varNr]));
         }
 
         Settings.TaskDeviceID[event->TaskIndex] = 1; // temp fix, needs a dummy value
@@ -169,12 +166,9 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
         {
           success = true;
           argIndex = string.lastIndexOf(',');
-          tmpString = string.substring(argIndex + 1);
-          char tmp[40];
-          tmpString.toCharArray(tmp, 40);
-          urlDecode(tmp);
+          tmpString = urlDecode(string.substring(argIndex + 1).c_str());
           lcd.setCursor(event->Par2 - 1, event->Par1 - 1);
-          lcd.print(tmp);
+          lcd.print(tmpString.c_str());
         }
         break;
       }

--- a/_P023_OLED.ino
+++ b/_P023_OLED.ino
@@ -73,11 +73,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
           String arg = "Plugin_023_template";
           arg += varNr + 1;
           arg.toCharArray(argc, 25);
-          String tmpString = WebServer.arg(argc);
-          char tmp[64];
-          tmpString.toCharArray(tmp, 64);
-          urlDecode(tmp);
-          strcpy(deviceTemplate[varNr], tmp);
+          String tmpString = urlDecode(WebServer.arg(argc).c_str());
+          strncpy(deviceTemplate[varNr], tmpString.c_str(), sizeof(deviceTemplate[varNr]));
         }
 
         Settings.TaskDeviceID[event->TaskIndex] = 1; // temp fix, needs a dummy value
@@ -91,7 +88,7 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
       {
         Plugin_023_StartUp_OLED();
         Plugin_023_clear_display();
-        Plugin_023_sendStrXY((char*)"ESP Easy ", 0, 0);
+        Plugin_023_sendStrXY("ESP Easy ", 0, 0);
         success = true;
         break;
       }
@@ -160,10 +157,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
             }
             newString += tmpString;
           }
-          char tmp[17];
-          newString.toCharArray(tmp, 17);
-          if (tmp[0] !=0 )
-            Plugin_023_sendStrXY(tmp, x, 0);
+          if (newString.length() )
+            Plugin_023_sendStrXY(newString.c_str(), x, 0);
         }
         success = false;
         break;
@@ -179,11 +174,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
         {
           success = true;
           argIndex = string.lastIndexOf(',');
-          tmpString = string.substring(argIndex+1);
-          char tmp[40];
-          tmpString.toCharArray(tmp,40);
-          urlDecode(tmp);
-          Plugin_023_sendStrXY(tmp, event->Par1 - 1, event->Par2 - 1);
+          tmpString = urlDecode(string.substring(argIndex+1).c_str());
+          Plugin_023_sendStrXY(tmpString.c_str(), event->Par1 - 1, event->Par2 - 1);
         }
         break;
       }
@@ -400,7 +392,7 @@ static void Plugin_023_sendStr(unsigned char *string)
 
 // Prints a string in coordinates X Y, being multiples of 8.
 // This means we have 16 COLS (0-15) and 8 ROWS (0-7).
-static void Plugin_023_sendStrXY( char *string, int X, int Y)
+static void Plugin_023_sendStrXY(const char *string, int X, int Y)
 {
   Plugin_023_setXY(X, Y);
   unsigned char i = 0;


### PR DESCRIPTION
Change method signatur from chat* to const char * to be able to use the String c_str() method to pass the contens of a String as a Pointer. So we can dissmiss the local buffers. There is no need for using the toCharArray method.

This solves a problem in my WIFI Setup where the handle_config() methods truncates the WifiKey containig 64 symbols with some ! ~ 0x21 coming form the web formular.
