### PR TITLE
Added option for measuring internal VCC

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -109,7 +109,7 @@
 // Enable FEATURE_ADC_VCC to measure supply voltage using the analog pin
 // Please note that the TOUT pin has to be disconnected in this mode
 // Use the "Analog Input" device to read the VCC value
-#define FEATURE_ADC_VCC                  true
+#define FEATURE_ADC_VCC                  false
 
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -109,7 +109,7 @@
 // Enable FEATURE_ADC_VCC to measure supply voltage using the analog pin
 // Please note that the TOUT pin has to be disconnected in this mode
 // Use the "Analog Input" device to read the VCC value
-#define FEATURE_ADC_VCC                  false
+#define FEATURE_ADC_VCC                  true
 
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE
@@ -608,6 +608,10 @@ void setup()
 #if FEATURE_TIME
     if (Settings.UseNTP)
       initTime();
+#endif
+
+#if FEATURE_ADC_VCC
+    vcc = ESP.getVcc() / 1000.0;
 #endif
 
     // Start DNS, only used if the ESP has no valid WiFi config

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -72,7 +72,7 @@
 // ********************************************************************************
 
 // Set default configuration settings if you want (not mandatory)
-// You can allways change these during runtime and save to eeprom
+// You can always change these during runtime and save to eeprom
 // After loading firmware, issue a 'reset' command to load the defaults.
 
 #define DEFAULT_NAME        "newdevice"         // Enter your device friendly name
@@ -105,6 +105,12 @@
 
 #define FEATURE_TIME                     true
 #define FEATURE_SSDP                     true
+
+// Enable FEATURE_ADC_VCC to measure supply voltage using the analog pin
+// Please note that the TOUT pin has to be disconnected in this mode
+// Use the "Analog Input" device to read the VCC value
+#define FEATURE_ADC_VCC                  false
+
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE
 // ********************************************************************************
@@ -213,6 +219,9 @@
 ESP8266HTTPUpdateServer httpUpdater(true);
 #if ESP_CORE >= 210
   #include <base64.h>
+#endif
+#if FEATURE_ADC_VCC
+ADC_MODE(ADC_VCC);
 #endif
 #define LWIP_OPEN_SRC
 #include "lwip/opt.h"
@@ -431,6 +440,10 @@ boolean AP_Mode = false;
 byte cmd_within_mainloop = 0;
 unsigned long connectionFailures;
 unsigned long wdcounter = 0;
+
+#if FEATURE_ADC_VCC
+float vcc = -1.0;
+#endif
 
 boolean WebLoggedIn = false;
 int WebLoggedInTimer = 300;
@@ -758,6 +771,9 @@ void runEach30Seconds()
   if (Settings.UseSSDP)
     SSDP_update();
 #endif
+#if FEATURE_ADC_VCC
+  vcc = ESP.getVcc() / 1000.0;
+#endif
   loopCounterLast = loopCounter;
   loopCounter = 0;
   if (loopCounterLast > loopCounterMax)
@@ -846,7 +862,7 @@ void SensorSendTask(byte TaskIndex)
     if (success)
     {
       for (byte varNr = 0; varNr < VARS_PER_TASK; varNr++)
-      {
+      {  
         if (ExtraTaskSettings.TaskDeviceFormula[varNr][0] != 0)
         {
           String spreValue = String(preValue[varNr]);

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -108,7 +108,7 @@
 
 // Enable FEATURE_ADC_VCC to measure supply voltage using the analog pin
 // Please note that the TOUT pin has to be disconnected in this mode
-// Use the "Analog Input" device to read the VCC value
+// Use the "System Info" device to read the VCC value
 #define FEATURE_ADC_VCC                  false
 
 // ********************************************************************************

--- a/Misc.ino
+++ b/Misc.ino
@@ -401,7 +401,7 @@ void fileSystemCheck()
 {
   if (SPIFFS.begin())
   {
-    String log = F("SPIFFS Mount succesfull");
+    String log = F("SPIFFS Mount successful");
     addLog(LOG_LEVEL_INFO, log);
     File f = SPIFFS.open("config.txt", "r");
     if (!f)
@@ -1195,6 +1195,7 @@ String parseTemplate(String &tmpString, byte lineSize)
                 {
                   // here we know the task and value, so find the uservar
                   String value = toString(UserVar[y * VARS_PER_TASK + z], ExtraTaskSettings.TaskDeviceValueDecimals[z]);
+                  
                   if (valueFormat == "R")
                   {
                     int filler = lineSize - newString.length() - value.length() - tmpString.length() ;
@@ -1231,6 +1232,10 @@ String parseTemplate(String &tmpString, byte lineSize)
 #endif
 
   newString.replace("%uptime%", String(wdcounter / 2));
+
+#if FEATURE_ADC_VCC
+  newString.replace("%vcc%", String(vcc));
+#endif
 
   IPAddress ip = WiFi.localIP();
   char strIP[20];

--- a/_C001.ino
+++ b/_C001.ino
@@ -147,7 +147,7 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_DEBUG_MORE, log);
           if (line.substring(0, 15) == "HTTP/1.1 200 OK")
           {
-            strcpy_P(log, PSTR("HTTP : Succes!"));
+            strcpy_P(log, PSTR("HTTP : Success"));
             addLog(LOG_LEVEL_DEBUG, log);
             success = true;
           }

--- a/_P026_Sysinfo.ino
+++ b/_P026_Sysinfo.ino
@@ -21,6 +21,7 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].ValueCount = 1;
         Device[deviceCount].SendDataOption = true;
         Device[deviceCount].TimerOption = true;
+        Device[deviceCount].FormulaOption = true;
         break;
       }
 
@@ -39,16 +40,18 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
       {
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-        String options[3];
+        String options[4];
         options[0] = F("Uptime");
         options[1] = F("Free RAM");
         options[2] = F("Wifi RSSI");
-        int optionValues[3];
+        options[3] = F("Input VCC");
+        int optionValues[4];
         optionValues[0] = 0;
         optionValues[1] = 1;
         optionValues[2] = 2;
+        optionValues[3] = 3;
         string += F("<TR><TD>Indicator:<TD><select name='plugin_026'>");
-        for (byte x = 0; x < 3; x++)
+        for (byte x = 0; x < 4; x++)
         {
           string += F("<option value='");
           string += optionValues[x];
@@ -91,6 +94,15 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
           case 2:
           {
             value = WiFi.RSSI();
+            break;
+          }
+          case 3:
+          {
+#if FEATURE_ADC_VCC
+            value = vcc;
+#else
+            value = -1.0;
+#endif
             break;
           }
         }


### PR DESCRIPTION
- Added `FEATURE_ADC_VCC` to compile option with default of false
- Added new `%vcc%` parameter, collected twice a minute
- Added `Internal VCC` option to *System Info* device
- Enabled formula option on *System Info* device so that decimals can be configured
