### PR TITLE
Fixed ThingSpeak and EmonCMS HTTP code

### DIFF
--- a/_C004.ino
+++ b/_C004.ino
@@ -51,7 +51,8 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
         if (connectionFailures)
           connectionFailures--;
 
-        String postDataStr = SecuritySettings.ControllerPassword; // "0UDNN17RW6XAS2E5" // api key
+        String postDataStr = F("api_key=");
+        postDataStr += SecuritySettings.ControllerPassword; // "0UDNN17RW6XAS2E5" // api key
 
         switch (event->sensorType)
         {
@@ -88,18 +89,27 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
             postDataStr += toString(UserVar[event->BaseVarIndex + 2],ExtraTaskSettings.TaskDeviceValueDecimals[2]);
             break;
         }
-        postDataStr += F("\r\n\r\n");
+        //postDataStr += F("\r\n\r\n"); // PM_CZ: Removed - breaks the last value on the line
 
-        String postStr = F("POST /update HTTP/1.1\n");
-        postStr += F("Host: api.thingspeak.com\n");
-        postStr += F("Connection: close\n");
+        String hostName = F("api.thingspeak.com"); // PM_CZ: HTTP requests must contain host headers.
+        if (Settings.UseDNS)
+          hostName = Settings.ControllerHostName;
+
+        String postStr = F("POST /update HTTP/1.1\r\n");
+        postStr += F("Host: ");
+        postStr += hostName;
+        postStr += F("\r\n");
+        postStr += F("Connection: close\r\n");
+
+/*      // PM_CZ: Following code is not necessary when sending api_key in POST data the correct way
         postStr += F("X-THINGSPEAKAPIKEY: ");
         postStr += SecuritySettings.ControllerPassword;
-        postStr += "\n";
-        postStr += F("Content-Type: application/x-www-form-urlencoded\n");
+        postStr += "\r\n";
+*/
+        postStr += F("Content-Type: application/x-www-form-urlencoded\r\n");
         postStr += F("Content-Length: ");
         postStr += postDataStr.length();
-        postStr += F("\n\n");
+        postStr += F("\r\n\r\n");
         postStr += postDataStr;
 
         // This will send the request to the server

--- a/_C007.ino
+++ b/_C007.ino
@@ -97,22 +97,19 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
         }
         postDataStr += F("&apikey=");
         postDataStr += SecuritySettings.ControllerPassword; // "0UDNN17RW6XAS2E5" // api key
-        
-        postDataStr += F("\r\n\r\n");
 
-        String postStr = F("POST /update HTTP/1.1\n");
-        postStr += F("Host: emoncms.org\n");
-        postStr += F("Connection: close\n");
-        postStr += F("X-EMONCMSAPIKEY: ");
-        postStr += SecuritySettings.ControllerPassword;
-        postStr += "\n";
-        postStr += F("Content-Type: application/x-www-form-urlencoded\n");
-        postStr += F("Content-Length: ");
-        postStr += postDataStr.length();
-        postStr += F("\n\n");
+        String hostName = host;
+        if (Settings.UseDNS)
+          hostName = Settings.ControllerHostName;
+
+        String postStr = F(" HTTP/1.1\r\n");
+        postStr += F("Host: ");
+        postStr += hostName;
+        postStr += F("\r\n");
+        postStr += F("Connection: close\r\n");
+        postStr += F("\r\n");
+
         postDataStr += postStr;
-        
-        //postStr += postDataStr;
 
         if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
           Serial.println(postDataStr);


### PR DESCRIPTION
Hello,
originally I found out that ThingSpeak API results in last value on line being stored as a 3-line string and wanted to fix that. However, when I have looked into the code, I found that there were some more issues with the ThingSpeak API code and that the EmonCMS code is seriously broken (but it kind-of worked anyway). 

This pull request does several things:
- Adds correct Host headers based on the set hostname (or the default working ones if IP address is entered - IP for EmonCMS and api.thinkspeak.com for ThingSpeak)
- Removes the extra two linebreaks in both variants of the code
- adds the missing api_key= to ThingSpeak (and comments out the now-unneeded X-THINGSPEAKAPIKEY:, sparing some bytes in every transmission)
- removes the X-EMONCMSAPIKEY:, which was probably the renamed X-THINGSPEAKAPIKEY and AFAIK does not exist at all.
- All EOLs for headers were converted to correct \r\n sequences as defined in HTTP