### PR TITLE
Generic HTTP fine grained control

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -112,6 +112,12 @@
 // Use the "System Info" device to read the VCC value
 #define FEATURE_ADC_VCC                  false
 
+// HTTP Request field size for Settings.
+#define HTTP_METHOD_MAX_LEN         10
+#define HTTP_URI_MAX_LEN	          501
+#define HTTP_HEADER_MAX_LEN         501
+#define HTTP_BODY_MAX_LEN           501
+
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE
 // ********************************************************************************
@@ -331,6 +337,13 @@ struct SettingsStruct
   boolean       GlobalSync;
   unsigned long ConnectionFailuresThreshold;
   int16_t       TimeZone;
+
+  // HTTP Request settings.
+  char          HttpMethod[HTTP_METHOD_MAX_LEN];
+  char          HttpUri[HTTP_URI_MAX_LEN];
+  char          HttpHeader[HTTP_HEADER_MAX_LEN];
+  char          HttpBody[HTTP_BODY_MAX_LEN];
+
 } Settings;
 
 struct ExtraTaskSettingsStruct
@@ -390,6 +403,13 @@ struct ProtocolStruct
   boolean usesAccount;
   boolean usesPassword;
   int defaultPort;
+
+  // HTTP Request protocol.
+  boolean selectHttpMethod;
+  boolean defineHttpUri;
+  boolean defineHttpHeader;
+  boolean defineHttpBody;
+
 } Protocol[CPLUGIN_MAX];
 
 struct NodeStruct

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -319,6 +319,13 @@ void handle_config() {
   String protocol = WebServer.arg("protocol");
   String controlleruser = WebServer.arg("controlleruser");
   String controllerpassword = WebServer.arg("controllerpassword");
+
+  // HTTP Request : args received when form submitted.
+  String httpmethod = WebServer.arg("httpmethod");
+  String httpuri = WebServer.arg("httpuri");
+  String httpheader = WebServer.arg("httpheader");
+  String httpbody = WebServer.arg("httpbody");
+
   String sensordelay = WebServer.arg("delay");
   String deepsleep = WebServer.arg("deepsleep");
   String espip = WebServer.arg("espip");
@@ -364,6 +371,18 @@ void handle_config() {
         }
 
         Settings.ControllerPort = controllerport.toInt();
+        
+        // HTTP Request : save the form input into the Settings.
+        byte ProtocolIndex = getProtocolIndex(Settings.Protocol);
+        if (Protocol[ProtocolIndex].selectHttpMethod)
+          strncpy(Settings.HttpMethod, httpmethod.c_str(), sizeof(Settings.HttpMethod));
+        if (Protocol[ProtocolIndex].defineHttpUri)
+          strncpy(Settings.HttpUri, httpuri.c_str(), sizeof(Settings.HttpUri));
+        if (Protocol[ProtocolIndex].defineHttpHeader)
+          strncpy(Settings.HttpHeader, httpheader.c_str(), sizeof(Settings.HttpHeader));
+        if (Protocol[ProtocolIndex].defineHttpBody)
+          strncpy(Settings.HttpBody, httpbody.c_str(), sizeof(Settings.HttpBody));
+
         strncpy(SecuritySettings.ControllerUser, controlleruser.c_str(), sizeof(SecuritySettings.ControllerUser));
         strncpy(SecuritySettings.ControllerPassword, controllerpassword.c_str(), sizeof(SecuritySettings.ControllerPassword));
       }
@@ -455,30 +474,74 @@ void handle_config() {
     {
       reply += F("<TR><TD>Controller Hostname:<TD><input type='text' name='controllerhostname' size='64' value='");
       reply += Settings.ControllerHostName;
+      reply += F("'>");
     }
     else
     {
       reply += F("<TR><TD>Controller IP:<TD><input type='text' name='controllerip' value='");
       sprintf_P(str, PSTR("%u.%u.%u.%u"), Settings.Controller_IP[0], Settings.Controller_IP[1], Settings.Controller_IP[2], Settings.Controller_IP[3]);
       reply += str;
+      reply += F("'>");
     }
 
-    reply += F("'><TR><TD>Controller Port:<TD><input type='text' name='controllerport' value='");
+    reply += F("<TR><TD>Controller Port:<TD><input type='text' name='controllerport' value='");
     reply += Settings.ControllerPort;
+    reply += F("'>");
 
     byte ProtocolIndex = getProtocolIndex(Settings.Protocol);
     if (Protocol[ProtocolIndex].usesAccount)
     {
-      reply += F("'><TR><TD>Controller User:<TD><input type='text' name='controlleruser' value='");
+      reply += F("<TR><TD>Controller User:<TD><input type='text' name='controlleruser' value='");
       reply += SecuritySettings.ControllerUser;
+      reply += F("'>");
     }
 
     if (Protocol[ProtocolIndex].usesPassword)
     {
-      reply += F("'><TR><TD>Controller Password:<TD><input type='text' name='controllerpassword' value='");
+      reply += F("<TR><TD>Controller Password:<TD><input type='text' name='controllerpassword' value='");
       reply += SecuritySettings.ControllerPassword;
+      reply += F("'>");
     }
-    reply += F("'>");
+
+    //
+    // HTTP Request custom configuration form.
+    //
+    if (Protocol[ProtocolIndex].selectHttpMethod)
+    {
+      String methods[] = { F("GET"), F("POST"), F("PUT") };
+      reply += F("<TR><TD>HTTP Method :<TD><select name='httpmethod'>");
+      for (int i=0; i < 3; i++)
+      {
+        reply += F("<option value='");
+        reply += methods[i] + "'";
+        reply += methods[i].equals(Settings.HttpMethod) ? F(" selected='selected'"): F("");
+        reply += F(">");
+        reply += methods[i];
+        reply += F("</option>");
+      }
+      reply += F("</select>");
+    }
+    
+    if (Protocol[ProtocolIndex].defineHttpUri)
+    {
+      reply += F("<TR><TD>HTTP URI:<TD><input type='text' name='httpuri' maxlength='500' value='");
+      reply += Settings.HttpUri;
+      reply += F("'>");
+    }
+
+    if (Protocol[ProtocolIndex].defineHttpHeader)
+    {
+      reply += F("<TR><TD>HTTP Header:<TD><textarea name='httpheader' rows='4' cols='50' maxlength='500'>");
+      reply += Settings.HttpHeader;
+      reply += F("</textarea>");
+    }
+
+    if (Protocol[ProtocolIndex].defineHttpBody)
+    {
+      reply += F("<TR><TD>HTTP Body:<TD><textarea name='httpbody' rows='8' cols='50' maxlength='500'>");
+      reply += Settings.HttpBody;
+      reply += F("</textarea>");
+    }
   }
 
   reply += F("<TR><TD>Sensor Delay:<TD><input type='text' name='delay' value='");


### PR DESCRIPTION
Hi,

I made some improvement on the Generic HTTP controller.
You can now select the HTTP method between GET (for compatibility issue), POST & PUT.
You can fully define the URI (instead of relying on the MQTT publish template value).
You can define the HTTP Header as you want and even add some %dynamic% variable that will be replaced by values.
You can define the HTTP Body & use the %dynamic% concept to retreive some values.

The needs was about being able to comply with a JSON REST API, this is now done.

![snip_20160722233435](https://cloud.githubusercontent.com/assets/13554171/17071943/ecf50c9c-5064-11e6-97c0-cd7f9551824c.png)

Regards,

Olivier.