### PR TITLE
Fix uninitialized variable and buffer overflow (found with cppcheck)

### DIFF
--- a/Misc.ino
+++ b/Misc.ino
@@ -1096,7 +1096,7 @@ unsigned long string2TimeLong(String &str)
   unsigned long a;
   str.toLowerCase();
   str.toCharArray(command, 20);
-  unsigned long lngTime;
+  unsigned long lngTime = 0;
 
   if (GetArgv(command, TmpStr1, 1))
   {

--- a/_P020_Ser2Net.ino
+++ b/_P020_Ser2Net.ino
@@ -146,8 +146,8 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
             int count = ser2netClient.available();
             if (count > 0)
             {
-              if (count > BUFFER_SIZE)
-                count = BUFFER_SIZE;
+              if (count >= BUFFER_SIZE)
+                count = BUFFER_SIZE - 1;
               bytes_read = ser2netClient.read(net_buf, count);
               Serial.write(net_buf, bytes_read);
               Serial.flush();


### PR DESCRIPTION
Please find attached a proposed fix for two issues found with cppcheck.
One is a fix for a potential buffer overflow, attempting to write to 1 byte past a buffer.
The other is a fix for an uninitialized variable, a value is ORed with the variable, but the initial value of the variable is undefined. The fix set the initial value to 0. 