### PR TITLE
FHEM HTTP: Fixed sensor_type_switch, sensor_type_dimmer

### DIFF
--- a/_C009.ino
+++ b/_C009.ino
@@ -150,8 +150,10 @@ boolean CPlugin_009(byte function, struct EventStruct *event, String& string)
             url += toString(UserVar[event->BaseVarIndex + 2],ExtraTaskSettings.TaskDeviceValueDecimals[2]);
             break;
           case SENSOR_TYPE_SWITCH:
-            url += F("set%20");
+            url += F("setreading%20");
             url += Settings.Name;
+            url += F("%20");
+            url += ExtraTaskSettings.TaskDeviceValueNames[0];
             url += F("%20");
             if (UserVar[event->BaseVarIndex] == 0)
               url += "off";
@@ -159,14 +161,15 @@ boolean CPlugin_009(byte function, struct EventStruct *event, String& string)
               url += "on";
             break;
           case SENSOR_TYPE_DIMMER:
-            url += F("set%20");
+            url += F("setreading%20");
             url += Settings.Name;
+            url += F("%20");
+            url += ExtraTaskSettings.TaskDeviceValueNames[0];
             url += F("%20");
             if (UserVar[event->BaseVarIndex] == 0)
               url += "off";
             else
             {
-              url += F("pct%20");
               url += UserVar[event->BaseVarIndex];
             }
             break;


### PR DESCRIPTION
Hi @mvdbro,

this fix will handle sensor_type_switch and dimmer in the same way as for all other sensor types.

Btw: The current "FHEM HTTP" plugin will work out of the box with FHEM, but some users requested a more flexible way. For that reason I wrote a FHEM module that will be more configurable. Unfortunately this will not work with thie current cplugin. Would you accept a new cplugin "FHEM JSON"? The current cplugin "FHEM HTTP" should still exist because it is the easiest way for inexperienced users and it is already in use.