### PR TITLE
DHT12 support (single wire and I2C)

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -39,7 +39,7 @@
 //   Analog input (ESP-7/12 only)
 //   Pulse counters
 //   Dallas OneWire DS18b20 temperature sensors
-//   DHT11/22 humidity sensors
+//   DHT11/22/12 humidity sensors
 //   BMP085 I2C Barometric Pressure sensor
 //   PCF8591 4 port Analog to Digital converter (I2C)
 //   RFID Wiegand-26 reader

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -1478,6 +1478,9 @@ void handle_i2cscanner() {
         case 0x48:
           reply += F("PCF8591 ADC");
           break;
+        case 0x5C:
+          reply += F("DHT 12");
+          break;
         case 0x68:
           reply += F("DS1307 RTC");
           break;

--- a/_P034_DHT12.ino
+++ b/_P034_DHT12.ino
@@ -1,0 +1,113 @@
+//#######################################################################################################
+//######################## Plugin 034: Temperature and Humidity sensor DHT 12 (I2C) #####################
+//#######################################################################################################
+
+#define PLUGIN_034
+#define PLUGIN_ID_034         34
+#define PLUGIN_NAME_034       "Temperature & Humidity - DHT12 (I2C)"
+#define PLUGIN_VALUENAME1_034 "Temperature"
+#define PLUGIN_VALUENAME2_034 "Humidity"
+
+boolean Plugin_034_init = false;
+
+#define DHT12_I2C_ADDRESS      0x5C // I2C address for the sensor
+
+boolean Plugin_034(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
+
+  switch (function)
+  {
+    case PLUGIN_DEVICE_ADD:
+      {
+        Device[++deviceCount].Number = PLUGIN_ID_034;
+        Device[deviceCount].Type = DEVICE_TYPE_I2C;
+        Device[deviceCount].VType = SENSOR_TYPE_TEMP_HUM;
+        Device[deviceCount].Ports = 0;
+        Device[deviceCount].PullUpOption = false;
+        Device[deviceCount].InverseLogicOption = false;
+        Device[deviceCount].FormulaOption = true;
+        Device[deviceCount].ValueCount = 2;
+        Device[deviceCount].SendDataOption = true;
+        Device[deviceCount].TimerOption = true;
+        Device[deviceCount].GlobalSyncOption = true;
+        break;
+      }
+
+    case PLUGIN_GET_DEVICENAME:
+      {
+        string = F(PLUGIN_NAME_034);
+        break;
+      }
+
+    case PLUGIN_GET_DEVICEVALUENAMES:
+      {
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_034));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_034));
+        break;
+      }
+
+    case PLUGIN_READ:
+      {
+        byte dht_dat[5];
+        byte dht_in;
+        byte i;
+        byte Retry = 0;
+        boolean error = false;
+
+        Wire.beginTransmission(DHT12_I2C_ADDRESS); // start transmission to device
+        Wire.write(0); // sends register address to read from
+        Wire.endTransmission(); // end transmission
+
+        Wire.beginTransmission(DHT12_I2C_ADDRESS); // start transmission to device
+        if (Wire.requestFrom(DHT12_I2C_ADDRESS, 5) == 5) { // send data n-bytes read
+          for (i = 0; i < 5; i++)
+          {
+            dht_dat[i] = Wire.read(); // receive DATA
+          }
+        } else {
+          error = true;
+        }
+        if (!error)
+        {
+          // Checksum calculation is a Rollover Checksum by design!
+          byte dht_check_sum = dht_dat[0] + dht_dat[1] + dht_dat[2] + dht_dat[3]; // check check_sum
+
+          if (dht_dat[4] == dht_check_sum)
+          {
+            float temperature = float(dht_dat[2]*10 + (dht_dat[3] & 0x7f)) / 10.0; // Temperature
+            if (dht_dat[3] & 0x80) { temperature = -temperature; }
+            float humidity = float(dht_dat[0]*10+dht_dat[1]) / 10.0; // Humidity
+
+            UserVar[event->BaseVarIndex] = temperature;
+            UserVar[event->BaseVarIndex + 1] = humidity;
+            String log = F("DHT12: Temperature: ");
+            log += UserVar[event->BaseVarIndex];
+            addLog(LOG_LEVEL_INFO, log);
+            log = F("DHT12: Humidity: ");
+            log += UserVar[event->BaseVarIndex + 1];
+            addLog(LOG_LEVEL_INFO, log);
+/*
+            log = F("DHT12: Data: ");
+            for (int i=0; i < 5; i++)
+            {
+              log +=  dht_dat[i];
+              log += ", ";
+            }
+            addLog(LOG_LEVEL_INFO, log);
+*/
+            success = true;
+          } // checksum
+        } // error
+        if(!success)
+        {
+          String log = F("DHT12: No reading!");
+          addLog(LOG_LEVEL_INFO, log);
+          UserVar[event->BaseVarIndex] = NAN;
+          UserVar[event->BaseVarIndex + 1] = NAN;
+        }
+        break;
+      }
+  }
+  return success;
+}


### PR DESCRIPTION
Hello, I have obtained some DHT-12 sensors and modified the ESPEasy to support them in both modes (the original DHT single wire interface where this module may be used as a drop-in replacement of DHT11 and the I2C which required creation of another plugin).

In fact, the DHT-12 is backward-compatible with DHT-11 in its temperature range, but it will not work correctly outside of it with DHT-11 code (subzero temperatures). Maybe the DHT-11 could be used with DHT-12 code, but I felt safer to keep them separate (in case of undefined values in bytes 1 and 3). I have also added the I2C scan entry for DHT-12.

Finally, I have also changed two other things in DHT plugin:
- the case where temperature and humidity equals to zero was modified to NAN values (I hope it did not have another reason, but it correctly works with removed module) in case of such real  measurement.
- the "DHT  : No reading!" message was moved where it will be really added to the log in case of failure and the forgotten NaN value which was added to the string has been  removed from the log entry.