### PR TITLE
Fix compiler warnings on ESPEasy firmware

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -232,7 +232,9 @@ ESP8266HTTPUpdateServer httpUpdater(true);
 #if FEATURE_ADC_VCC
 ADC_MODE(ADC_VCC);
 #endif
+#ifndef LWIP_OPEN_SRC
 #define LWIP_OPEN_SRC
+#endif
 #include "lwip/opt.h"
 #include "lwip/udp.h"
 #include "lwip/igmp.h"

--- a/_P001_Switch.ino
+++ b/_P001_Switch.ino
@@ -232,7 +232,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           {
             pinMode(event->Par1, OUTPUT);
             
-            if(event->Par3 != NULL)
+            if(event->Par3 != 0)
             {
               byte prev_mode;
               uint16_t prev_value;            


### PR DESCRIPTION
I always compile with warnings turned on
* LWIP_OPEN_SRC is redefined
* event->Par3 is 'int', not pointer, so it should be compared against a number instead of NULL
```
C:\Users\tonia\Documents\Arduino\ESPEasy\ESPEasy.ino:235:0: warning: "LWIP_OPEN_SRC" redefined [enabled by default]

 #define LWIP_OPEN_SRC

 ^

<command-line>:0:0: note: this is the location of the previous definition

C:\Users\tonia\Documents\Arduino\ESPEasy\_P001_Switch.ino: In function 'boolean Plugin_001(byte, EventStruct*, String&)':

C:\Users\tonia\Documents\Arduino\ESPEasy\_P001_Switch.ino:235:31: warning: NULL used in arithmetic [-Wpointer-arith]

             if(event->Par3 != NULL)

                               ^
```