### PR TITLE
Changes in BMP/BME280 code

### DIFF
--- a/WebServer.ino
+++ b/WebServer.ino
@@ -1467,7 +1467,9 @@ void handle_i2cscanner() {
         case 0x24:
           reply += F("PN532 RFID Reader");
           break;
+        case 0x29:
         case 0x39:
+        case 0x49:
           reply += F("TLS2561 Lux Sensor");
           break;
         case 0x3C:
@@ -1490,7 +1492,8 @@ void handle_i2cscanner() {
           reply += F("BME280/BMP280/MS5607/MS5611");
           break;
         case 0x77:
-          reply += F("BMP085/MS5607/MS5611");
+          reply += F("BMP085/");
+          reply += F("BME280/BMP280/MS5607/MS5611"); //pm-cz Optimization should recycle this string from above
           break;
         case 0x7f:
           reply += F("Arduino Pro Mini IO Extender");

--- a/_P028_BME280.ino
+++ b/_P028_BME280.ino
@@ -170,7 +170,10 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
           UserVar[event->BaseVarIndex] = Plugin_028_readTemperature();
           UserVar[event->BaseVarIndex + 1] = ((float)Plugin_028_readHumidity());
           UserVar[event->BaseVarIndex + 2] = ((float)Plugin_028_readPressure()) / 100;
-          String log = F("BME  : Temperature: ");
+          String log = F("BME  : Address: 0x");
+          log += String(_i2caddr,HEX);
+          addLog(LOG_LEVEL_INFO, log);
+          log = F("BME  : Temperature: ");
           log += UserVar[event->BaseVarIndex];
           addLog(LOG_LEVEL_INFO, log);
           log = F("BME  : Humidity: ");

--- a/_P028_BME280.ino
+++ b/_P028_BME280.ino
@@ -162,7 +162,7 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
         if (!Plugin_028_init[idx])
         {
           Plugin_028_init[idx] = Plugin_028_begin(Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
-         //delay(45); //May be needed here as well to fix first wrong measurement?
+          delay(65); //May be needed here as well to fix first wrong measurement?
         }
 
         if (Plugin_028_init[idx])

--- a/_P030_BMP280.ino
+++ b/_P030_BMP280.ino
@@ -146,11 +146,14 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
           delay(65); // Ultra high resolution for BMP280 is 43.2 ms, add some extra time
         }
 
-        if (Plugin_030_init[idx]) 
+        if (Plugin_030_init[idx])
         {
           UserVar[event->BaseVarIndex] = Plugin_030_readTemperature();
           UserVar[event->BaseVarIndex + 1] = ((float)Plugin_030_readPressure()) / 100;
-          String log = F("BMP280  : Temperature: ");
+          String log = F("BMP280  : Address: 0x");
+          log += String(bmp280_i2caddr,HEX);
+          addLog(LOG_LEVEL_INFO, log);
+          log = F("BMP280  : Temperature: ");
           log += UserVar[event->BaseVarIndex];
           addLog(LOG_LEVEL_INFO, log);
           log = F("BMP280  : Barometric Pressure: ");
@@ -182,11 +185,11 @@ bool Plugin_030_check(uint8_t a) {
 // Initialize BMP280
 //**************************************************************************/
 bool Plugin_030_begin(uint8_t a) {
-  if (! Plugin_030_check(a)) 
+  if (! Plugin_030_check(a))
     return false;
 
   Plugin_030_readCoefficients();
-  Plugin_030_write8(BMP280_REGISTER_CONTROL, BMP280_CONTROL_SETTING); 
+  Plugin_030_write8(BMP280_REGISTER_CONTROL, BMP280_CONTROL_SETTING);
   return true;
 }
 

--- a/_P030_BMP280.ino
+++ b/_P030_BMP280.ino
@@ -34,6 +34,7 @@ enum
   BMP280_REGISTER_CONFIG             = 0xF5,
   BMP280_REGISTER_PRESSUREDATA       = 0xF7,
   BMP280_REGISTER_TEMPDATA           = 0xFA,
+
   BMP280_CONTROL_SETTING             = 0x57, // Oversampling: 16x P, 2x T, normal mode
 };
 
@@ -137,7 +138,7 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
       {
         uint8_t idx = Settings.TaskDevicePluginConfig[event->TaskIndex][0] & 0x1; //Addresses are 0x76 and 0x77 so we may use it this way
         Plugin_030_init[idx] &= Plugin_030_check(Settings.TaskDevicePluginConfig[event->TaskIndex][0]); // Check id device is present
-        Plugin_030_init[idx] &=  (Plugin_030_read8(BMP280_REGISTER_CONTROL) == BMP280_CONTROL_SETTING); // Check if the coefficients are OK
+        Plugin_030_init[idx] &=  (Plugin_030_read8(BMP280_REGISTER_CONTROL) == BMP280_CONTROL_SETTING); // Check if the coefficients are still valid
 
         if (!Plugin_030_init[idx])
         {
@@ -145,7 +146,8 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
           delay(65); // Ultra high resolution for BMP280 is 43.2 ms, add some extra time
         }
 
-        if (Plugin_030_init[idx]) {
+        if (Plugin_030_init[idx]) 
+        {
           UserVar[event->BaseVarIndex] = Plugin_030_readTemperature();
           UserVar[event->BaseVarIndex + 1] = ((float)Plugin_030_readPressure()) / 100;
           String log = F("BMP280  : Temperature: ");
@@ -164,19 +166,6 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
 }
 
 //**************************************************************************/
-// Initialize BMP280
-//**************************************************************************/
-bool Plugin_030_begin(uint8_t a) {
-  if (! Plugin_030_check(a)) {
-      return false;
-  }
-
-  Plugin_030_readCoefficients();
-  Plugin_030_write8(BMP280_REGISTER_CONTROL, BMP280_CONTROL_SETTING); 
-  return true;
-}
-
-//**************************************************************************/
 // Check BMP280 presence
 //**************************************************************************/
 bool Plugin_030_check(uint8_t a) {
@@ -187,6 +176,18 @@ bool Plugin_030_check(uint8_t a) {
   } else {
       return wire_status;
   }
+}
+
+//**************************************************************************/
+// Initialize BMP280
+//**************************************************************************/
+bool Plugin_030_begin(uint8_t a) {
+  if (! Plugin_030_check(a)) 
+    return false;
+
+  Plugin_030_readCoefficients();
+  Plugin_030_write8(BMP280_REGISTER_CONTROL, BMP280_CONTROL_SETTING); 
+  return true;
 }
 
 //**************************************************************************/

--- a/_P030_BMP280.ino
+++ b/_P030_BMP280.ino
@@ -34,6 +34,7 @@ enum
   BMP280_REGISTER_CONFIG             = 0xF5,
   BMP280_REGISTER_PRESSUREDATA       = 0xF7,
   BMP280_REGISTER_TEMPDATA           = 0xFA,
+  BMP280_CONTROL_SETTING             = 0x57, // Oversampling: 16x P, 2x T, normal mode
 };
 
 typedef struct
@@ -59,7 +60,9 @@ uint8_t bmp280_i2caddr;
 int32_t bmp280_sensorID;
 int32_t bmp280_t_fine;
 
-boolean Plugin_030_init = false;
+uint8_t Plugin_030_read8(byte reg, bool * is_ok = NULL); // Declaration
+
+boolean Plugin_030_init[2] = {false, false};
 
 boolean Plugin_030(byte function, struct EventStruct *event, String& string)
 {
@@ -132,13 +135,17 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ:
       {
-        if (!Plugin_030_init)
+        uint8_t idx = Settings.TaskDevicePluginConfig[event->TaskIndex][0] & 0x1; //Addresses are 0x76 and 0x77 so we may use it this way
+        Plugin_030_init[idx] &= Plugin_030_check(Settings.TaskDevicePluginConfig[event->TaskIndex][0]); // Check id device is present
+        Plugin_030_init[idx] &=  (Plugin_030_read8(BMP280_REGISTER_CONTROL) == BMP280_CONTROL_SETTING); // Check if the coefficients are OK
+
+        if (!Plugin_030_init[idx])
         {
-          Plugin_030_init = Plugin_030_begin(Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
-          delay(60); // Ultra high resolution for BMP280 is 43.2 ms, add some extra time
+          Plugin_030_init[idx] = Plugin_030_begin(Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
+          delay(65); // Ultra high resolution for BMP280 is 43.2 ms, add some extra time
         }
 
-        if (Plugin_030_init) {
+        if (Plugin_030_init[idx]) {
           UserVar[event->BaseVarIndex] = Plugin_030_readTemperature();
           UserVar[event->BaseVarIndex + 1] = ((float)Plugin_030_readPressure()) / 100;
           String log = F("BMP280  : Temperature: ");
@@ -160,15 +167,26 @@ boolean Plugin_030(byte function, struct EventStruct *event, String& string)
 // Initialize BMP280
 //**************************************************************************/
 bool Plugin_030_begin(uint8_t a) {
-  bmp280_i2caddr = a;
-
-  if (Plugin_030_read8(BMP280_REGISTER_CHIPID) != 0x58) {
+  if (! Plugin_030_check(a)) {
       return false;
   }
 
   Plugin_030_readCoefficients();
-  Plugin_030_write8(BMP280_REGISTER_CONTROL, 0x3F);
+  Plugin_030_write8(BMP280_REGISTER_CONTROL, BMP280_CONTROL_SETTING); 
   return true;
+}
+
+//**************************************************************************/
+// Check BMP280 presence
+//**************************************************************************/
+bool Plugin_030_check(uint8_t a) {
+  bmp280_i2caddr = a;
+  bool wire_status = false;
+  if (Plugin_030_read8(BMP280_REGISTER_CHIPID, &wire_status) != 0x58) {
+      return false;
+  } else {
+      return wire_status;
+  }
 }
 
 //**************************************************************************/
@@ -185,14 +203,15 @@ void Plugin_030_write8(byte reg, byte value)
 //**************************************************************************/
 // Reads an 8 bit value over I2C
 //**************************************************************************/
-uint8_t Plugin_030_read8(byte reg)
+uint8_t Plugin_030_read8(byte reg, bool * is_ok)
 {
   uint8_t value;
 
   Wire.beginTransmission((uint8_t)bmp280_i2caddr);
   Wire.write((uint8_t)reg);
   Wire.endTransmission();
-  Wire.requestFrom((uint8_t)bmp280_i2caddr, (byte)1);
+  byte count = Wire.requestFrom((uint8_t)bmp280_i2caddr, (byte)1);
+  if (is_ok != NULL) { *is_ok = (count == 1); }
   value = Wire.read();
   Wire.endTransmission();
   return value;
@@ -210,6 +229,23 @@ uint16_t Plugin_030_read16(byte reg)
   Wire.endTransmission();
   Wire.requestFrom((uint8_t)bmp280_i2caddr, (byte)2);
   value = (Wire.read() << 8) | Wire.read();
+  Wire.endTransmission();
+
+  return value;
+}
+
+//**************************************************************************/
+// Reads a 24 bit value over I2C
+//**************************************************************************/
+int32_t Plugin_030_read24(byte reg)
+{
+  int32_t value;
+
+  Wire.beginTransmission((uint8_t)bmp280_i2caddr);
+  Wire.write((uint8_t)reg);
+  Wire.endTransmission();
+  Wire.requestFrom((uint8_t)bmp280_i2caddr, (byte)3);
+  value = (((int32_t)Wire.read()) << 16) | (Wire.read() << 8) | Wire.read();
   Wire.endTransmission();
 
   return value;
@@ -266,9 +302,7 @@ float Plugin_030_readTemperature(void)
 {
   int32_t var1, var2;
 
-  int32_t adc_T = Plugin_030_read16(BMP280_REGISTER_TEMPDATA);
-  adc_T <<= 8;
-  adc_T |= Plugin_030_read8(BMP280_REGISTER_TEMPDATA + 2);
+  int32_t adc_T = Plugin_030_read24(BMP280_REGISTER_TEMPDATA);
   adc_T >>= 4;
 
   var1  = ((((adc_T >> 3) - ((int32_t)_bmp280_calib.dig_T1 << 1))) *
@@ -290,9 +324,7 @@ float Plugin_030_readTemperature(void)
 float Plugin_030_readPressure(void) {
   int64_t var1, var2, p;
 
-  int32_t adc_P = Plugin_030_read16(BMP280_REGISTER_PRESSUREDATA);
-  adc_P <<= 8;
-  adc_P |= Plugin_030_read8(BMP280_REGISTER_PRESSUREDATA + 2);
+  int32_t adc_P = Plugin_030_read24(BMP280_REGISTER_PRESSUREDATA);
   adc_P >>= 4;
 
   var1 = ((int64_t)bmp280_t_fine) - 128000;


### PR DESCRIPTION
Hello,
when looking for some small problems with both types of the sensors, I did update the code slightly and did following changes:
- Corrected the control byte value according to the recommendations in the datasheet (from 0x3F to 0x57) and placed it in separate enum value - BMP280_CONTROL_SETTING)
- Copied support for secondary address to BME code (untested as my BME does have only a soldering point for address selection, but it works on BMP280)
- Made it possible to use two BME280 or BMP280 sensors at the same time (other than using it for pressurized/unpressurized area I am not sure if anybody will make use of it)
- added checks should the sensor reset (the values were wrongly calculated at that time) and reinitialize it in such case
- added initial delay after initialization for BME280 as well (it was already in my BMP280 code, but I was able to get invalid results from BME280 without it as well)
- added a bulk read of pressure/temperature value - only then is the consistency of the value ensured according ito the datasheet (shadowing) - read24 function
- Added info about address to log output
- Added basic checking that at least one byte is read from the BME/BMP via i2c (read8 secondary argument with default NULL value if unused)

Plus, since I was changing the WebServer code, I did include the detection for I2C TLS2561 Lux Sensor other addresses (L, H).
