### PR TITLE
Support LIFX smart bulb

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -181,6 +181,91 @@ void ExecuteCommand(byte source, const char *Line)
     portUDP.endPacket();
   }
 
+#if FEATURE_LIFX
+#define LIFX_UDP_PORT     56700
+
+  if (strcasecmp_P(Command, PSTR("SendToLIFX")) == 0)
+  {
+    uint8_t data[50];
+    uint8_t msglength;
+    uint32_t duration=0;
+    
+    success = true;
+    String strLine = Line;
+    String cmd = parseString(strLine,2);
+    String value1 = parseString(strLine,3);
+    String value2 = parseString(strLine,4);
+    String value3 = parseString(strLine,5);
+    String value4 = parseString(strLine,6);
+    String value5 = parseString(strLine,7);
+
+    if (cmd == "power") {
+      Serial.print(F("SendToLIFX, Set Power, value= ")); Serial.println(value1);
+      int state = atoi(value1.c_str());
+      if (value2.length() > 0) {
+        duration = atoi(value2.c_str());
+      }
+      msglength = getPktSetBulbPower(data, state, duration);
+    }
+    else { // color
+      Serial.println("SendToLIFX, Set color " + value1 + " " + value2 + " " + value3 + " " + value4);
+
+      if (value2.length() > 0) {
+        duration = atoi(value2.c_str());
+      }
+      
+      if (strcasecmp_P(value1.c_str(),PSTR("RED")) == 0) {
+        msglength = getPktSetBulbColor(data,62978,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("CYAN")) == 0) {
+        msglength = getPktSetBulbColor(data,29814,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("ORANGE")) == 0) {
+        msglength = getPktSetBulbColor(data,5525,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("YELLOW")) == 0) {
+        msglength = getPktSetBulbColor(data,7615,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("GREEN")) == 0) {
+        msglength = getPktSetBulbColor(data,16173,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("BLUE")) == 0) {
+        msglength = getPktSetBulbColor(data,43634,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("PURPLE")) == 0) {
+        msglength = getPktSetBulbColor(data,50486,65535,65535,3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("PINK")) == 0) {
+        msglength = getPktSetBulbColor(data,50486, 65535, 65535, 3500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("WHITE")) == 0) {
+        msglength = getPktSetBulbColor(data,58275, 0, 65535, 5500, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("COLD_WHTE")) == 0) {
+        msglength = getPktSetBulbColor(data,58275, 0, 65535, 9000, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("WARM_WHITE")) == 0) {
+        msglength = getPktSetBulbColor(data,58275, 0, 65535, 3200, duration);
+      }
+      else if (strcasecmp_P(value1.c_str(),PSTR("GOLD")) == 0) {
+        msglength = getPktSetBulbColor(data,58275, 0, 65535, 2500, duration);
+      }
+      else {
+        duration = 0;
+        if (value5.length() > 0) {
+          duration = atoi(value5.c_str());
+        }
+        msglength = getPktSetBulbColor(data, atoi(value1.c_str()), atoi(value2.c_str()), atoi(value3.c_str()), atoi(value4.c_str()), duration);
+      }
+    }
+
+    IPAddress UDP_IP(Settings.LifxIP[0], Settings.LifxIP[1], Settings.LifxIP[2], Settings.LifxIP[3]);
+    
+    portUDP.beginPacket(UDP_IP, LIFX_UDP_PORT);
+    portUDP.write(data, msglength);
+    portUDP.endPacket();
+  }
+#endif
   if (strcasecmp_P(Command, PSTR("SendToHTTP")) == 0)
   {
     success = true;

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -63,6 +63,7 @@
 //   MSP5611 I2C temp/baro sensor
 //   BMP280 I2C Barometric Pressure sensor
 //   SHT1X temperature/humidity sensors
+//	 LIFX smart buld (tested on Color 1000)
 
 //   Experimental/Preliminary:
 //   =========================
@@ -114,6 +115,8 @@
 // Please note that the TOUT pin has to be disconnected in this mode
 // Use the "System Info" device to read the VCC value
 #define FEATURE_ADC_VCC                  false
+// Support for LIFX light bulb (experimental) : LAN protocol, SendToLIFX command in rules
+#define FEATURE_LIFX                     false
 
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE
@@ -342,6 +345,8 @@ struct SettingsStruct
   unsigned long ConnectionFailuresThreshold;
   int16_t       TimeZone;
   boolean       MQTTRetainFlag;
+  byte          LifxIP[4];
+  byte          LifxMAC[6];
 } Settings;
 
 struct ExtraTaskSettingsStruct

--- a/Misc.ino
+++ b/Misc.ino
@@ -593,6 +593,25 @@ boolean str2ip(char *string, byte* IP)
   return false;
 }
 
+/********************************************************************************************\
+  Convert a String representing a MAC address to byte array
+  \*********************************************************************************************/
+void str2mac(String string, byte* MAC)
+{
+  String tmpString = string;
+  tmpString += ":";
+  String locateString = "";
+  byte count = 0;
+  int index = tmpString.indexOf(':');
+  while (count < 6)
+  {
+    locateString = tmpString.substring(0, index);
+    tmpString = tmpString.substring(index + 1);
+    MAC[count] = (byte)strtol(locateString.c_str(), NULL, 16);
+    index = tmpString.indexOf(':');
+    count++;
+  }
+}
 
 /********************************************************************************************\
   Save settings to SPIFFS

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -1739,6 +1739,10 @@ void handle_advanced() {
   String userules = WebServer.arg("userules");
   String cft = WebServer.arg("cft");
   String MQTTRetainFlag = WebServer.arg("mqttretainflag");
+#if FEATURE_LIFX
+  String lifxip = WebServer.arg("lifxip");
+  String lifxmac = WebServer.arg("lifxmac");
+#endif
 
   if (edit.length() != 0)
   {
@@ -1771,6 +1775,11 @@ void handle_advanced() {
     Settings.GlobalSync = (globalsync == "on");
     Settings.ConnectionFailuresThreshold = cft.toInt();
     Settings.MQTTRetainFlag = (MQTTRetainFlag == "on");
+#if FEATURE_LIFX
+    lifxip.toCharArray(tmpString, 26);
+    str2ip(tmpString, Settings.LifxIP);
+    str2mac(lifxmac, Settings.LifxMAC);
+#endif
     SaveSettings();
 #if FEATURE_TIME
     if (Settings.UseNTP)
@@ -1897,6 +1906,21 @@ void handle_advanced() {
   else
     reply += F("<input type=checkbox name='globalsync'>");
 
+#if FEATURE_LIFX
+  reply += F("<TR><TH>LIFX Settings<TH>Value");
+
+  reply += F("<TR><TD>IP address:<TD><input type='text' name='lifxip' value='");
+  str[0] = 0;
+  sprintf_P(str, PSTR("%u.%u.%u.%u"), Settings.LifxIP[0], Settings.LifxIP[1], Settings.LifxIP[2], Settings.LifxIP[3]);
+  reply += str;
+  reply += F("'>");
+
+  reply += F("<TR><TD>MAC address:<TD><input type='text' name='lifxmac' value='");
+  str[0] = 0;
+  sprintf_P(str, PSTR("%02x:%02x:%02x:%02x:%02x:%02x"), Settings.LifxMAC[0], Settings.LifxMAC[1], Settings.LifxMAC[2], Settings.LifxMAC[3], Settings.LifxMAC[4], Settings.LifxMAC[5]);
+  reply += str;
+  reply += F("'>");
+#endif
   reply += F("<TR><TD><TD><input class=\"button-link\" type='submit' value='Submit'>");
   reply += F("<input type='hidden' name='edit' value='1'>");
   reply += F("</table></form>");

--- a/_LIFX.ino
+++ b/_LIFX.ino
@@ -1,0 +1,121 @@
+
+typedef struct __attribute__((packed)) {
+  // Framce
+  uint16_t msgsize;
+  uint16_t protocol;
+  uint32_t source;    // 32 bits/uint32, unique ID set by client. If zero, broadcast reply
+  
+  // Frame address
+  uint8_t target_mac[8];  // 64 bits/uint64, either single MAC address or all zeroes for broadcast.
+  uint8_t reserved1[6];
+  uint8_t ctrl;           // 6 first bits are reserved, next bit ack_required, next bit res_required (response message)
+  uint8_t seq_num;        // Message sequence number (will be provided in response if response is requested)
+
+  // Protcol Header
+  uint64_t reserved2;
+  uint16_t packet_type;   // Message type determines the payload being used
+  uint16_t reserved3;
+  
+} lx_header_t;
+
+typedef struct __attribute__((packed)) {
+  uint8_t   rfu;
+  uint16_t  hue;
+  uint16_t  saturation;
+  uint16_t  brightness;
+  uint16_t  kelvin;
+  uint32_t  duration;
+} setcolor_102_t;
+
+typedef struct __attribute__((packed)) {
+  uint16_t  level;
+  uint32_t  duration;
+} setpower_117_t;
+
+
+void getPktSetBulbPower2(uint8_t * data, uint16_t state) {
+  lx_header_t * tmp;
+ 
+  tmp = (lx_header_t *)data;
+
+  memset(data, 0, 38);
+  tmp->msgsize = 38;
+
+  tmp->protocol = 0x1400;  // PROTOCOL_COMMAND
+  tmp->packet_type = 0x15; // Device message : set power state (21 dec)
+  memcpy(&tmp->target_mac, Settings.LifxMAC, 6);
+  memcpy(&tmp->source, "didi", 4);
+  
+  // The payload
+  memcpy(&data[36], &state, 2);
+
+  print_msg_serial(data, 38);
+}
+
+
+uint16_t getPktSetBulbPower(uint8_t * data, int state, uint32_t duration) {
+  lx_header_t * tmp;
+  setpower_117_t * tmp2;
+
+  tmp = (lx_header_t *)data;
+
+  memset(data, 0, 42);
+  
+  tmp->msgsize = 42; // 36 (header) + 6 (setpower payload)
+
+  tmp->protocol = 0x1400;  // PROTOCOL_COMMAND
+  tmp->packet_type = 117; // Light message : SetPower - 117 (0x75)
+  memcpy(&tmp->target_mac, Settings.LifxMAC, 6);
+  memcpy(&tmp->source, "didi", 4);
+  
+  // The payload : https://lan.developer.lifx.com/docs/light-messages#section-setpower-117
+  tmp2 = (setpower_117_t *)&data[36];
+  tmp2->level = state;
+  tmp2->duration = duration;
+
+  print_msg_serial(data, tmp->msgsize);
+  
+  return tmp->msgsize;
+}
+
+
+uint16_t getPktSetBulbColor(uint8_t * data, uint16_t h, uint16_t s, uint16_t b, uint16_t k, uint32_t duration) {
+  lx_header_t * tmp;
+  setcolor_102_t * tmp2;
+
+  tmp = (lx_header_t *)data;
+
+  memset(data, 0, 49);
+
+  tmp->msgsize = 49; // 36 (header) + 13 (setcolor payload)
+  
+  tmp->protocol = 0x1400;  // PROTOCOL_COMMAND
+  tmp->packet_type = 102; // Light message : SetColor - 102 (0x66)
+  memcpy(&tmp->target_mac, Settings.LifxMAC, 6);
+  memcpy(&tmp->source, "didi", 4);
+  
+  // The payload HSBK : https://lan.developer.lifx.com/docs/light-messages#section-hsbk
+  tmp2 = (setcolor_102_t *)&data[36];
+  tmp2->duration = duration;
+  tmp2->hue = h;
+  tmp2->saturation = s;
+  tmp2->brightness = b;
+  tmp2->kelvin = k;
+
+  print_msg_serial(data, tmp->msgsize);
+  
+  return tmp->msgsize;
+}
+
+void print_msg_serial(uint8_t * data, uint16_t len) {
+   char str[10];
+   for (int i=0 ; i<len; i++) {
+      sprintf_P(str, PSTR("%02x "), data[i]);
+      if ( (i+1) % 8 == 0 )
+        Serial.println(str);
+      else
+        Serial.print(str);
+   }
+   Serial.println("");
+}
+


### PR DESCRIPTION
Tested on model Color 1000 only, but should work with other models. Uses UDP protocol on LAN (not the cloud API). 
This is neither a controller, nor a sensor. I did not use any prefix for the new file name. Not sure it matches the ESPEasy "strategy".
I compiled and tested on build 107. I merged my change in build 126 but did not manage to compile and test again yet (I guess local IDE stuff).