### PR TITLE
Extend Pulse Counter with "Total" counter type

### DIFF
--- a/_P003_Pulse.ino
+++ b/_P003_Pulse.ino
@@ -60,8 +60,8 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
         String options[3];
         options[0] = F("Delta");
-        options[1] = F("Total");        
-        options[2] = F("Delta/Total/Time");
+        options[1] = F("Delta/Total/Time");
+        options[2] = F("Total");        
         int optionValues[3];
         optionValues[0] = 0;
         optionValues[1] = 1;
@@ -138,16 +138,16 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
           }
           case 1:
           {
-            event->sensorType = SENSOR_TYPE_SINGLE;
-            UserVar[event->BaseVarIndex] = Plugin_003_pulseTotalCounter[event->TaskIndex];
-            break;
-          }
-          case 2:
-          {
             event->sensorType = SENSOR_TYPE_TRIPLE;
             UserVar[event->BaseVarIndex] = Plugin_003_pulseCounter[event->TaskIndex];
             UserVar[event->BaseVarIndex+1] = Plugin_003_pulseTotalCounter[event->TaskIndex];
             UserVar[event->BaseVarIndex+2] = Plugin_003_pulseTime[event->TaskIndex];
+            break;
+          }
+          case 2:
+          {
+            event->sensorType = SENSOR_TYPE_SINGLE;
+            UserVar[event->BaseVarIndex] = Plugin_003_pulseTotalCounter[event->TaskIndex];
             break;
           }
         }

--- a/_P003_Pulse.ino
+++ b/_P003_Pulse.ino
@@ -58,14 +58,16 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
         string += tmpString;
 
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-        String options[2];
+        String options[3];
         options[0] = F("Delta");
-        options[1] = F("Delta/Total/Time");
-        int optionValues[2];
+        options[1] = F("Total");        
+        options[2] = F("Delta/Total/Time");
+        int optionValues[3];
         optionValues[0] = 0;
         optionValues[1] = 1;
+        optionValues[2] = 2;
         string += F("<TR><TD>Counter Type:<TD><select name='plugin_003_countertype'>");
-        for (byte x = 0; x < 2; x++)
+        for (byte x = 0; x < 3; x++)
         {
           string += F("<option value='");
           string += optionValues[x];
@@ -131,11 +133,21 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
           case 0:
           {
             event->sensorType = SENSOR_TYPE_SINGLE;
+            UserVar[event->BaseVarIndex] = Plugin_003_pulseCounter[event->TaskIndex];
             break;
           }
           case 1:
           {
+            event->sensorType = SENSOR_TYPE_SINGLE;
+            UserVar[event->BaseVarIndex] = Plugin_003_pulseTotalCounter[event->TaskIndex];
+            break;
+          }
+          case 2:
+          {
             event->sensorType = SENSOR_TYPE_TRIPLE;
+            UserVar[event->BaseVarIndex] = Plugin_003_pulseCounter[event->TaskIndex];
+            UserVar[event->BaseVarIndex+1] = Plugin_003_pulseTotalCounter[event->TaskIndex];
+            UserVar[event->BaseVarIndex+2] = Plugin_003_pulseTime[event->TaskIndex];
             break;
           }
         }


### PR DESCRIPTION
This pull request extends the Pulse Counter plugin with a new counter type to only publish a single value for the Total. The total value published will be sent as value #1 (default name: "Count").

Use case is to allow a central automation system to accurately keep track of counter values without the risk of missing data (in case "Delta" type would be used) or sending unnecessary data (in case of the "Delta/Total/Time"  type). 

Tested successfully for all 3 counter types.

![image](https://cloud.githubusercontent.com/assets/1499454/18648559/74d6524a-7ebb-11e6-9cb6-b355776b36e7.png)

