### PR TITLE
Add pressure altitude correction into formulas

### DIFF
--- a/Misc.ino
+++ b/Misc.ino
@@ -1349,7 +1349,7 @@ float globalstack[STACK_SIZE];
 float *sp = globalstack - 1;
 float *sp_max = &globalstack[STACK_SIZE - 1];
 
-#define is_operator(c)  (c == '+' || c == '-' || c == '*' || c == '/' )
+#define is_operator(c)  (c == '+' || c == '-' || c == '*' || c == '/' || c == '@')
 
 int push(float value)
 {
@@ -1380,6 +1380,9 @@ float apply_operator(char op, float first, float second)
       return first * second;
     case '/':
       return first / second;
+    case '@':
+      return pressureElevation(first, second);
+    default:
       return 0;
   }
 }
@@ -1595,6 +1598,9 @@ int Calculate(const char *input, float* result)
   return CALCULATE_OK;
 }
 
+float pressureElevation(float atmospheric, float altitude) {
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
+}
 
 /********************************************************************************************\
   Time stuff

--- a/Misc.ino
+++ b/Misc.ino
@@ -1423,6 +1423,8 @@ int op_preced(const char c)
 {
   switch (c)
   {
+    case '@':
+      return 3;
     case '*':
     case '/':
       return 2;
@@ -1437,6 +1439,7 @@ bool op_left_assoc(const char c)
 {
   switch (c)
   {
+    case '@':
     case '*':
     case '/':
     case '+':
@@ -1451,6 +1454,7 @@ unsigned int op_arg_count(const char c)
 {
   switch (c)
   {
+    case '@':
     case '*':
     case '/':
     case '+':


### PR DESCRIPTION
Based on suggestions I made to #74, this is a simple adjustment to formula engine, adding `@` operator. This will allow to recalculate the pressure altitude according to following formula:
`atmospheric / pow(1.0 - (altitude/44330.0), 5.255);`

It should be noted that unless pow function is used elsewhere, it will be added making the binary slightly larger. 

Also some very old (~09/2015) versions of ESP Arduino board library may not support pow function, is this an issue? The formula according to https://github.com/adafruit/Adafruit_BMP085_Unified/pull/15 would be in this case
`atmospheric / exp(5.255 * log(1.0 - (altitude/44330.0)));`
