### PR TITLE
Add pressure altitude adjustments to individual sensors

### DIFF
--- a/_P006_BMP085.ino
+++ b/_P006_BMP085.ino
@@ -283,7 +283,7 @@ boolean Plugin_006_bmp085_write8(uint8_t a, uint8_t d)
 }
 
 /*********************************************************************/
-float Plugin_006_pressureElevation(float atmospheric, float altitude) {
+float Plugin_006_pressureElevation(float atmospheric, int altitude) {
 /*********************************************************************/
   return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }

--- a/_P006_BMP085.ino
+++ b/_P006_BMP085.ino
@@ -45,6 +45,24 @@ boolean Plugin_006(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_WEBFORM_LOAD:
+      {
+        string += F("<TR><TD>Altitude [m]:<TD><input type='text' title='Set Altitude to 0 to get measurement without altitude adjustment' name='");
+        string += F("_p006_bmp085_elev' value='");
+        string += Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+        string += F("'>");
+        success = true;
+        break;
+      }
+
+    case PLUGIN_WEBFORM_SAVE:
+      {
+        String elev = WebServer.arg("_p006_bmp085_elev");
+        Settings.TaskDevicePluginConfig[event->TaskIndex][1] = elev.toInt();
+        success = true;
+        break;
+      }
+
     case PLUGIN_READ:
       {
         if (!Plugin_006_init)
@@ -56,7 +74,13 @@ boolean Plugin_006(byte function, struct EventStruct *event, String& string)
         if (Plugin_006_init)
         {
           UserVar[event->BaseVarIndex] = Plugin_006_bmp085_readTemperature();
-          UserVar[event->BaseVarIndex + 1] = ((float)Plugin_006_bmp085_readPressure()) / 100;
+          int elev = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+          if (elev)
+          {
+             UserVar[event->BaseVarIndex + 1] = Plugin_006_pressureElevation((float)Plugin_006_bmp085_readPressure() / 100, elev);
+          } else {
+             UserVar[event->BaseVarIndex + 1] = ((float)Plugin_006_bmp085_readPressure()) / 100;
+          }
           String log = F("BMP  : Temperature: ");
           log += UserVar[event->BaseVarIndex];
           addLog(LOG_LEVEL_INFO, log);
@@ -256,4 +280,10 @@ boolean Plugin_006_bmp085_write8(uint8_t a, uint8_t d)
     return false;
 
   return true;
+}
+
+/*********************************************************************/
+float Plugin_006_pressureElevation(float atmospheric, float altitude) {
+/*********************************************************************/
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }

--- a/_P028_BME280.ino
+++ b/_P028_BME280.ino
@@ -140,6 +140,10 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
           string += F("</option>");
         }
         string += F("</select>");
+        string += F("<TR><TD>Altitude [m]:<TD><input type='text' title='Set Altitude to 0 to get measurement without altitude adjustment' name='");
+        string += F("plugin_028_bme280_elev' value='");
+        string += Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+        string += F("'>");
 
         success = true;
         break;
@@ -149,6 +153,8 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
       {
         String plugin1 = WebServer.arg("plugin_028_bme280_i2c");
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = plugin1.toInt();
+        String elev = WebServer.arg("plugin_028_bme280_elev");
+        Settings.TaskDevicePluginConfig[event->TaskIndex][1] = elev.toInt();
         success = true;
         break;
       }
@@ -169,7 +175,13 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
         {
           UserVar[event->BaseVarIndex] = Plugin_028_readTemperature(idx);
           UserVar[event->BaseVarIndex + 1] = ((float)Plugin_028_readHumidity(idx));
-          UserVar[event->BaseVarIndex + 2] = ((float)Plugin_028_readPressure(idx)) / 100;
+          int elev = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+          if (elev)
+          {
+             UserVar[event->BaseVarIndex + 2] = Plugin_028_pressureElevation((float)Plugin_028_readPressure(idx) / 100, elev);
+          } else {
+             UserVar[event->BaseVarIndex + 2] = ((float)Plugin_028_readPressure(idx)) / 100;
+          }
           String log = F("BME  : Address: 0x");
           log += String(_i2caddr,HEX);
           addLog(LOG_LEVEL_INFO, log);
@@ -191,11 +203,12 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
+
 //**************************************************************************/
 // Check BME280 presence
 //**************************************************************************/
 bool Plugin_028_check(uint8_t a) {
-  _i2caddr = a;
+  _i2caddr = a?a:0x76;
   bool wire_status = false;
   if (Plugin_028_read8(BME280_REGISTER_CHIPID, &wire_status) != 0x60) {
       return false;
@@ -208,8 +221,6 @@ bool Plugin_028_check(uint8_t a) {
 // Initialize BME280
 //**************************************************************************/
 bool Plugin_028_begin(uint8_t a) {
-  _i2caddr = a;
-
   if (! Plugin_028_check(a))
     return false;
 
@@ -427,5 +438,12 @@ float Plugin_028_readAltitude(float seaLevel)
 
   float atmospheric = Plugin_028_readPressure(_i2caddr & 0x01) / 100.0F;
   return 44330.0 * (1.0 - pow(atmospheric / seaLevel, 0.1903));
+}
+
+//**************************************************************************/
+// MSL pressure formula
+//**************************************************************************/
+float Plugin_028_pressureElevation(float atmospheric, float altitude) {
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }
 

--- a/_P028_BME280.ino
+++ b/_P028_BME280.ino
@@ -443,7 +443,7 @@ float Plugin_028_readAltitude(float seaLevel)
 //**************************************************************************/
 // MSL pressure formula
 //**************************************************************************/
-float Plugin_028_pressureElevation(float atmospheric, float altitude) {
+float Plugin_028_pressureElevation(float atmospheric, int altitude) {
   return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }
 

--- a/_P030_BMP280.ino
+++ b/_P030_BMP280.ino
@@ -407,7 +407,7 @@ float Plugin_030_readAltitude(float seaLevel)
 //**************************************************************************/
 // MSL pressure formula
 //**************************************************************************/
-float Plugin_030_pressureElevation(float atmospheric, float altitude) {
+float Plugin_030_pressureElevation(float atmospheric, int altitude) {
   return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }
 

--- a/_P032_MS5611.ino
+++ b/_P032_MS5611.ino
@@ -269,7 +269,7 @@ void Plugin_032_readout() {
 //**************************************************************************/
 // MSL pressure formula
 //**************************************************************************/
-float Plugin_032_pressureElevation(double atmospheric, float altitude) {
+double Plugin_032_pressureElevation(double atmospheric, int altitude) {
   return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }
 

--- a/_P032_MS5611.ino
+++ b/_P032_MS5611.ino
@@ -76,7 +76,7 @@ boolean Plugin_032(byte function, struct EventStruct *event, String& string)
         int optionValues[2];
         optionValues[0] = 0x77;
         optionValues[1] = 0x76;
-        string += F("<TR><TD>I2C Address:<TD><select name='plugin_032_bmp280_i2c'>");
+        string += F("<TR><TD>I2C Address:<TD><select name='plugin_032_ms5611_i2c'>");
         for (byte x = 0; x < 2; x++)
         {
           string += F("<option value='");
@@ -89,6 +89,10 @@ boolean Plugin_032(byte function, struct EventStruct *event, String& string)
           string += F("</option>");
         }
         string += F("</select>");
+        string += F("<TR><TD>Altitude [m]:<TD><input type='text' title='Set Altitude to 0 to get measurement without altitude adjustment' name='");
+        string += F("plugin_032_ms5611_elev' value='");
+        string += Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+        string += F("'>");
 
         success = true;
         break;
@@ -96,8 +100,10 @@ boolean Plugin_032(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
       {
-        String plugin1 = WebServer.arg("plugin_032_bmp280_i2c");
+        String plugin1 = WebServer.arg("plugin_032_ms5611_i2c");
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = plugin1.toInt();
+        String elev = WebServer.arg("plugin_032_ms5611_elev");
+        Settings.TaskDevicePluginConfig[event->TaskIndex][1] = elev.toInt();
         success = true;
         break;
       }
@@ -114,7 +120,14 @@ boolean Plugin_032(byte function, struct EventStruct *event, String& string)
           Plugin_032_readout();
           
           UserVar[event->BaseVarIndex] = ms5611_temperature / 100;
-          UserVar[event->BaseVarIndex + 1] = ms5611_pressure;
+          int elev = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+          if (elev)
+          {
+             UserVar[event->BaseVarIndex + 1] = Plugin_032_pressureElevation(ms5611_pressure, elev);
+          } else {
+             UserVar[event->BaseVarIndex + 1] = ms5611_pressure;
+          }
+
           String log = F("MS5611  : Temperature: ");
           log += UserVar[event->BaseVarIndex];
           addLog(LOG_LEVEL_INFO, log);
@@ -251,5 +264,12 @@ void Plugin_032_readout() {
   OFF-=OFF2;
   SENS-=SENS2;
   ms5611_pressure=(((D1*SENS)/pow(2,21)-OFF)/pow(2,15));  
+}
+
+//**************************************************************************/
+// MSL pressure formula
+//**************************************************************************/
+float Plugin_032_pressureElevation(double atmospheric, float altitude) {
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }
 


### PR DESCRIPTION
This is a continuation of #74 @adrianmihalko code, an alternative to #78 as requested there. Unlike his code, it contains only one field for the altitude, since we can disable the adjustment by setting altitude to 0 (which is also mentioned in tooltip). The advantage is that adjusted pressure is reported to logs as well. However this solution has also several disadvantages as I feared:
- The size of the binary grew much more 
- It is not possible to adjust the value by formula before calculating the MSL pressure
- It has to be done for each plugin separately

BMP085, BMP280 and BME280 have been tested, however I do not own  a MS5611, so even tripple-checked the code for MS5611 but is untested.