### PR TITLE
Display uptime as days:hours:minutes

### DIFF
--- a/WebServer.ino
+++ b/WebServer.ino
@@ -186,9 +186,18 @@ void handle_root() {
     }
 
     reply += F("<TR><TD>Uptime:<TD>");
-    reply += wdcounter / 2;
-    reply += F(" minutes");
-
+    /* reply += wdcounter / 2;
+    reply += F(" minutes"); */
+    char strUpTime[10]; /* enough for "9999:23:59" */
+    int minutes = wdcounter / 2;
+    int days = minutes / 1440;
+    minutes = minutes%1440; /* minutes now less than a day */
+    int hrs = minutes / 60;
+    minutes = minutes%60; /*minutes less than an hour*/
+    sprintf_P(strUpTime, PSTR("%d:%02d:%02d"),days, hrs, minutes);
+    reply += strUpTime;
+    reply += F(" days:hours:minutes");
+    
     if (WiFi.status() == WL_CONNECTED)
     {
       reply += F("<TR><TD>Wifi RSSI:<TD>");


### PR DESCRIPTION
This patch displays the uptime in the webpage as days:hours:minutes

It is displayed as:
Uptime  0:00:00 days:hours:minutes

The hours and minutes are always 2 decimals. The days are 1 to 4 decimals (9999 days is in my book more than enough).

So it can be displayed as:
Uptime  0:00:23 days:hours:minutes

Uptime  0:01:18 days:hours:minutes

Uptime  1:00:48 days:hours:minutes

Uptime  26:13:34 days:hours:minutes

I did not touch the uptime in Misc.ino. And I did not touch the uptime in ESPEasy.ino which is used for the log.

Even though "41068 Minutes" is an impressive number, I prefer "27:36:28 days:hours:minutes"
